### PR TITLE
支持自定义正则表达式匹配网页内容

### DIFF
--- a/common/httpx/customregex.go
+++ b/common/httpx/customregex.go
@@ -1,0 +1,16 @@
+package httpx
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ExtractInfo by custom regex from a response
+func ExtractInfoByCustomRegex(r *Response, regex string) (info string) {
+	var re = regexp.MustCompile(regex)
+	matchs := re.FindAllStringSubmatch(r.Raw, -1)
+	for _, match := range matchs {
+		info += strings.Join(match, "_")
+	}
+	return
+}

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -22,6 +22,7 @@ type scanOptions struct {
 	StoreResponseDirectory string
 	RequestURI             string
 	RequestBody            string
+	OutputCustomRegex      string
 	VHost                  bool
 	OutputTitle            bool
 	OutputStatusCode       bool
@@ -111,6 +112,7 @@ type Options struct {
 	NoFallback                bool
 	protocol                  string
 	ShowStatistics            bool
+	CustomRegex               string
 }
 
 // ParseOptions parses the command line options for application
@@ -123,6 +125,7 @@ func ParseOptions() *Options {
 	flag.StringVar(&options.Output, "o", "", "File to write output to (optional)")
 	flag.BoolVar(&options.VHost, "vhost", false, "Check for VHOSTs")
 	flag.BoolVar(&options.ExtractTitle, "title", false, "Extracts title")
+	flag.StringVar(&options.CustomRegex, "custom-regex", "", "Extracts information by custom regex")
 	flag.BoolVar(&options.StatusCode, "status-code", false, "Extracts status code")
 	flag.BoolVar(&options.Location, "location", false, "Extracts location header")
 	flag.Var(&options.CustomHeaders, "H", "Custom Header")

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -127,6 +127,7 @@ func New(options *Options) (*Runner, error) {
 	}
 	runner.options.protocol = httpx.HTTPorHTTPS
 	scanopts.VHost = options.VHost
+	scanopts.OutputCustomRegex = options.CustomRegex
 	scanopts.OutputTitle = options.ExtractTitle
 	scanopts.OutputStatusCode = options.StatusCode
 	scanopts.OutputLocation = options.Location
@@ -580,6 +581,17 @@ retry:
 			builder.WriteString(aurora.Cyan(title).String())
 		} else {
 			builder.WriteString(title)
+		}
+		builder.WriteRune(']')
+	}
+
+	if len(scanopts.OutputCustomRegex) != 0 {
+		customRegexInfo := httpx.ExtractInfoByCustomRegex(resp, scanopts.OutputCustomRegex)
+		builder.WriteString(" [")
+		if !scanopts.OutputWithNoColor {
+			builder.WriteString(aurora.Cyan(customRegexInfo).String())
+		} else {
+			builder.WriteString(customRegexInfo)
 		}
 		builder.WriteRune(']')
 	}


### PR DESCRIPTION
新增参数`-custom-regex`

该参数的值为自定义的正则表达式`需在首部添加"(?im)"`
