### PR TITLE
只输出`-custom-regex`中的子表达式内容

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-
+/.idea
 cmd/httpx/httpx
+cmd/httpx/domains.txt

--- a/common/httpx/customregex.go
+++ b/common/httpx/customregex.go
@@ -10,7 +10,7 @@ func ExtractInfoByCustomRegex(r *Response, regex string) (info string) {
 	var re = regexp.MustCompile(regex)
 	matchs := re.FindAllStringSubmatch(r.Raw, -1)
 	for _, match := range matchs {
-		info += strings.Join(match, "_")
+		info += strings.Join(match[1:], " | ")
 	}
 	return
 }


### PR DESCRIPTION
使用`-custom-regex`后,现在输出的是正则表达式的子表达式中的内容
例子:
```shell
cat domains.txt |  ./httpx -custom-regex "(?im)<title>(.*?)</title>"
```

输出:
```
http://127.0.0.1 [title]
```